### PR TITLE
fix(ci): Update go releaser to match go version 1.19

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # tag=v3.3.0
         with:
-          go-version: 1.18
+          go-version: 1.19
       - uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77 # tag=v3.0.8
         with:
           path: |


### PR DESCRIPTION
Updated go releaser yaml config to match the go version 1.19