### PR TITLE
fix: return nonzero status code if request was not successful

### DIFF
--- a/cmd/stackit-api-manager/cmd/project_fetch_api.go
+++ b/cmd/stackit-api-manager/cmd/project_fetch_api.go
@@ -36,7 +36,7 @@ func fetchCmdRunE(cmd *cobra.Command, args []string) error {
 	c := newAPIClient()
 
 	if strings.HasPrefix(authToken, "Bearer ") {
-		cmd.Printf("Authorization token should have no Bearer prefix: %w", errBadToken)
+		cmd.Printf("Authorization token should have no Bearer prefix")
 		return errBadToken
 	}
 	// add auth token

--- a/cmd/stackit-api-manager/cmd/project_fetch_api.go
+++ b/cmd/stackit-api-manager/cmd/project_fetch_api.go
@@ -25,16 +25,18 @@ func (r fetchResponse) successMessage() string {
 }
 
 var fetchCmd = &cobra.Command{ //nolint:gochecknoglobals // CLI command
-	Use:   "fetch",
-	Short: "Fetches the OpenAPI Spec and metadata for an existing Stackit API Gateway project API",
-	RunE:  fetchCmdRunE,
+	Use:           "fetch",
+	Short:         "Fetches the OpenAPI Spec and metadata for an existing Stackit API Gateway project API",
+	RunE:          fetchCmdRunE,
+	SilenceErrors: true,
+	SilenceUsage:  true,
 }
 
 func fetchCmdRunE(cmd *cobra.Command, args []string) error {
 	c := newAPIClient()
 
 	if strings.HasPrefix(authToken, "Bearer ") {
-		cmd.Printf("Authorization token should have no Bearer prefix")
+		cmd.Printf("Authorization token should have no Bearer prefix: %w", errBadToken)
 		return errBadToken
 	}
 	// add auth token
@@ -46,6 +48,7 @@ func fetchCmdRunE(cmd *cobra.Command, args []string) error {
 		identifier,
 	).Execute()
 	if err != nil && httpResp == nil {
+		cmd.Print(err)
 		return err
 	}
 	defer httpResp.Body.Close()

--- a/cmd/stackit-api-manager/cmd/project_list.go
+++ b/cmd/stackit-api-manager/cmd/project_list.go
@@ -21,16 +21,18 @@ func (r listResponse) successMessage() string {
 }
 
 var listCmd = &cobra.Command{ //nolint:gochecknoglobals // CLI command
-	Use:   "list",
-	Short: "List all API identifiers for a Stackit API Gateway project",
-	RunE:  listCmdRunE,
+	Use:           "list",
+	Short:         "List all API identifiers for a Stackit API Gateway project",
+	RunE:          listCmdRunE,
+	SilenceErrors: true,
+	SilenceUsage:  true,
 }
 
 func listCmdRunE(cmd *cobra.Command, args []string) error {
 	c := newAPIClient()
 
 	if strings.HasPrefix(authToken, "Bearer ") {
-		cmd.Printf("Authorization token should have no Bearer prefix")
+		cmd.Printf("Authorization token should have no Bearer prefix: %w", errBadToken)
 		return errBadToken
 	}
 	// add auth token
@@ -41,6 +43,7 @@ func listCmdRunE(cmd *cobra.Command, args []string) error {
 		projectID,
 	).Execute()
 	if err != nil && httpResp == nil {
+		cmd.Print(err)
 		return err
 	}
 	defer httpResp.Body.Close()

--- a/cmd/stackit-api-manager/cmd/project_list.go
+++ b/cmd/stackit-api-manager/cmd/project_list.go
@@ -32,7 +32,7 @@ func listCmdRunE(cmd *cobra.Command, args []string) error {
 	c := newAPIClient()
 
 	if strings.HasPrefix(authToken, "Bearer ") {
-		cmd.Printf("Authorization token should have no Bearer prefix: %w", errBadToken)
+		cmd.Printf("Authorization token should have no Bearer prefix")
 		return errBadToken
 	}
 	// add auth token

--- a/cmd/stackit-api-manager/cmd/project_publish.go
+++ b/cmd/stackit-api-manager/cmd/project_publish.go
@@ -79,11 +79,5 @@ func publishCmdRunE(cmd *cobra.Command, args []string) error {
 		APIURL:     grpcResp.GetApiUrl(),
 	}
 
-	err = printSuccessCLIResponse(cmd, httpResp.StatusCode, &publishResponse)
-	if err != nil {
-		cmd.Print(err)
-		return err
-	}
-
-	return nil
+	return printSuccessCLIResponse(cmd, httpResp.StatusCode, &publishResponse)
 }

--- a/cmd/stackit-api-manager/cmd/project_publish.go
+++ b/cmd/stackit-api-manager/cmd/project_publish.go
@@ -52,7 +52,7 @@ func publishCmdRunE(cmd *cobra.Command, args []string) error {
 	}
 
 	if strings.HasPrefix(authToken, "Bearer ") {
-		cmd.Printf("Authorization token should have no Bearer prefix: %w", errBadToken)
+		cmd.Printf("Authorization token should have no Bearer prefix")
 		return errBadToken
 	}
 	// add auth token

--- a/cmd/stackit-api-manager/cmd/project_retire.go
+++ b/cmd/stackit-api-manager/cmd/project_retire.go
@@ -21,9 +21,11 @@ func (r retireResponse) successMessage() string {
 }
 
 var retireCmd = &cobra.Command{ //nolint:gochecknoglobals // CLI command
-	Use:   "retire",
-	Short: "Retire a OpenAPI Spec from a Stackit API Gateway project",
-	RunE:  retireCmdRunE,
+	Use:           "retire",
+	Short:         "Retire a OpenAPI Spec from a Stackit API Gateway project",
+	RunE:          retireCmdRunE,
+	SilenceErrors: true,
+	SilenceUsage:  true,
 }
 
 func retireCmdRunE(cmd *cobra.Command, args []string) error {
@@ -32,7 +34,7 @@ func retireCmdRunE(cmd *cobra.Command, args []string) error {
 	req := apiManager.RetireRequest{}
 
 	if strings.HasPrefix(authToken, "Bearer ") {
-		cmd.Printf("Authorization token should have no Bearer prefix")
+		cmd.Printf("Authorization token should have no Bearer prefix: %w", errBadToken)
 		return errBadToken
 	}
 	// add auth token
@@ -44,6 +46,7 @@ func retireCmdRunE(cmd *cobra.Command, args []string) error {
 		identifier,
 	).RetireRequest(req).Execute()
 	if err != nil && httpResp == nil {
+		cmd.Print(err)
 		return err
 	}
 	defer httpResp.Body.Close()

--- a/cmd/stackit-api-manager/cmd/project_retire.go
+++ b/cmd/stackit-api-manager/cmd/project_retire.go
@@ -34,7 +34,7 @@ func retireCmdRunE(cmd *cobra.Command, args []string) error {
 	req := apiManager.RetireRequest{}
 
 	if strings.HasPrefix(authToken, "Bearer ") {
-		cmd.Printf("Authorization token should have no Bearer prefix: %w", errBadToken)
+		cmd.Printf("Authorization token should have no Bearer prefix")
 		return errBadToken
 	}
 	// add auth token

--- a/cmd/stackit-api-manager/cmd/project_test.go
+++ b/cmd/stackit-api-manager/cmd/project_test.go
@@ -80,11 +80,10 @@ func Test_publishCmdRunE(t *testing.T) {
 			args: projectCmdArgs{
 				openAPISpecFilePath: "./no-test.json",
 			},
-			mockNilResponse: false,
-			wantErr:         true,
+			wantErr: true,
 		},
 		{
-			name: "status code 400 - no error",
+			name: "status code 400 - error",
 			args: projectCmdArgs{
 				serverBaseURL:       mockServerURL,
 				authToken:           "some-auth-token",
@@ -99,7 +98,7 @@ func Test_publishCmdRunE(t *testing.T) {
 					statusCode: 400,
 				},
 			},
-			wantErr: false,
+			wantErr: true,
 		},
 		{
 			name: "nil http response - error",
@@ -124,7 +123,7 @@ func Test_publishCmdRunE(t *testing.T) {
 			if tt.mockNilResponse {
 				httpmock.Reset()
 			}
-			if err := publishCmdRunE(&cobra.Command{}, []string{}); (err != nil) != tt.wantErr {
+			if err := publishCmdRunE(&cobra.Command{Use: "publish"}, []string{}); (err != nil) != tt.wantErr {
 				t.Errorf("publishCmdRunE() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
@@ -159,7 +158,7 @@ func Test_retireCmdRunE(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "status code 400 - no error",
+			name: "status code 400 - error",
 			args: projectCmdArgs{
 				serverBaseURL: mockServerURL,
 				authToken:     "some-auth-token",
@@ -172,7 +171,7 @@ func Test_retireCmdRunE(t *testing.T) {
 					statusCode: 400,
 				},
 			},
-			wantErr: false,
+			wantErr: true,
 		},
 		{
 			name: "nil http response - error",
@@ -195,7 +194,7 @@ func Test_retireCmdRunE(t *testing.T) {
 			if tt.mockNilResponse {
 				httpmock.Reset()
 			}
-			if err := retireCmdRunE(&cobra.Command{}, []string{}); (err != nil) != tt.wantErr {
+			if err := retireCmdRunE(&cobra.Command{Use: "retire"}, []string{}); (err != nil) != tt.wantErr {
 				t.Errorf("retireCmdRunE() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
@@ -239,7 +238,7 @@ func Test_validateCmdRunE(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "status code 400 - no error",
+			name: "status code 400 - error",
 			args: projectCmdArgs{
 				serverBaseURL:       mockServerURL,
 				authToken:           "some-auth-token",
@@ -254,7 +253,7 @@ func Test_validateCmdRunE(t *testing.T) {
 					statusCode: 400,
 				},
 			},
-			wantErr: false,
+			wantErr: true,
 		},
 		{
 			name: "nil http response - error",
@@ -279,7 +278,7 @@ func Test_validateCmdRunE(t *testing.T) {
 			if tt.mockNilResponse {
 				httpmock.Reset()
 			}
-			if err := validateCmdRunE(&cobra.Command{}, []string{}); (err != nil) != tt.wantErr {
+			if err := validateCmdRunE(&cobra.Command{Use: "validate"}, []string{}); (err != nil) != tt.wantErr {
 				t.Errorf("validateCmdRunE() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
@@ -321,7 +320,7 @@ func Test_listCmdRunE(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "status code 400 - no error",
+			name: "status code 400 - error",
 			args: projectCmdArgs{
 				serverBaseURL: mockServerURL,
 				authToken:     "some-auth-token",
@@ -333,7 +332,7 @@ func Test_listCmdRunE(t *testing.T) {
 					statusCode: 400,
 				},
 			},
-			wantErr: false,
+			wantErr: true,
 		},
 		{
 			name: "nil http response - error",
@@ -358,7 +357,7 @@ func Test_listCmdRunE(t *testing.T) {
 			if tt.mockNilResponse {
 				httpmock.Reset()
 			}
-			if err := listCmdRunE(&cobra.Command{}, []string{}); (err != nil) != tt.wantErr {
+			if err := listCmdRunE(&cobra.Command{Use: "list"}, []string{}); (err != nil) != tt.wantErr {
 				t.Errorf("listCmdRunE() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
@@ -426,7 +425,7 @@ func Test_fetchAPICmsdRunE(t *testing.T) {
 		},
 
 		{
-			name: "status code 400 - no error",
+			name: "status code 400 - error",
 			args: projectCmdArgs{
 				serverBaseURL: mockServerURL,
 				authToken:     "some-auth-token",
@@ -439,7 +438,7 @@ func Test_fetchAPICmsdRunE(t *testing.T) {
 					statusCode: 400,
 				},
 			},
-			wantErr: false,
+			wantErr: true,
 		},
 		{
 			name: "nil http response - error",
@@ -464,7 +463,7 @@ func Test_fetchAPICmsdRunE(t *testing.T) {
 			if tt.mockNilResponse {
 				httpmock.Reset()
 			}
-			err := fetchCmdRunE(&cobra.Command{}, []string{})
+			err := fetchCmdRunE(&cobra.Command{Use: "fetch"}, []string{})
 			fmt.Printf("err: %v", err)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("fetchAPICmdRunE() error = %v, wantErr %v", err, tt.wantErr)

--- a/cmd/stackit-api-manager/cmd/project_test.go
+++ b/cmd/stackit-api-manager/cmd/project_test.go
@@ -1,3 +1,4 @@
+//nolint:dupl // ignore duplicates for test cases
 package cmd
 
 import (

--- a/cmd/stackit-api-manager/cmd/project_validate.go
+++ b/cmd/stackit-api-manager/cmd/project_validate.go
@@ -23,9 +23,11 @@ func (r validateResponse) successMessage() string {
 }
 
 var validateCmd = &cobra.Command{ //nolint:gochecknoglobals // CLI command
-	Use:   "validate",
-	Short: "Validate an OpenAPI Spec for a Stackit API Gateway project",
-	RunE:  validateCmdRunE,
+	Use:           "validate",
+	Short:         "Validate an OpenAPI Spec for a Stackit API Gateway project",
+	RunE:          validateCmdRunE,
+	SilenceErrors: true,
+	SilenceUsage:  true,
 }
 
 func validateCmdRunE(cmd *cobra.Command, args []string) error {
@@ -33,6 +35,7 @@ func validateCmdRunE(cmd *cobra.Command, args []string) error {
 
 	base64Encoded, err := util.EncodeBase64File(openAPISpecFilePath)
 	if err != nil {
+		cmd.Print(err)
 		return err
 	}
 
@@ -48,7 +51,7 @@ func validateCmdRunE(cmd *cobra.Command, args []string) error {
 	}
 
 	if strings.HasPrefix(authToken, "Bearer ") {
-		cmd.Printf("Authorization token should have no Bearer prefix")
+		cmd.Printf("Authorization token should have no Bearer prefix: %w", errBadToken)
 		return errBadToken
 	}
 	// add auth token
@@ -60,6 +63,7 @@ func validateCmdRunE(cmd *cobra.Command, args []string) error {
 		identifier,
 	).PublishValidateRequest(req).Execute()
 	if err != nil && httpResp == nil {
+		cmd.Print(err)
 		return err
 	}
 	defer httpResp.Body.Close()

--- a/cmd/stackit-api-manager/cmd/project_validate.go
+++ b/cmd/stackit-api-manager/cmd/project_validate.go
@@ -51,7 +51,7 @@ func validateCmdRunE(cmd *cobra.Command, args []string) error {
 	}
 
 	if strings.HasPrefix(authToken, "Bearer ") {
-		cmd.Printf("Authorization token should have no Bearer prefix: %w", errBadToken)
+		cmd.Printf("Authorization token should have no Bearer prefix")
 		return errBadToken
 	}
 	// add auth token

--- a/cmd/stackit-api-manager/cmd/response_util.go
+++ b/cmd/stackit-api-manager/cmd/response_util.go
@@ -74,7 +74,7 @@ func printSuccessCLIResponseHumanReadable(cmd *cobra.Command, cmdResponse cmdRes
 	case *validateResponse:
 		cmd.Printf("OpenAPI specification for API with identifier \"%s\", project \"%s\" and stage \"%s\" validated successfully\n", r.Identifier, r.ProjectID, r.Stage)
 	case *listResponse:
-		cmd.Printf("Project \"%s\" has the following identifiers: %+v", r.ProjectID, r.Identifiers)
+		cmd.Printf("Project \"%s\" has the following identifiers: %+v\n", r.ProjectID, r.Identifiers)
 	case *fetchResponse:
 		cmd.Printf("Base64 encoded OpenAPI specification for API with identifier \"%s\" for project \"%s\" and stage \"%s\" (API-URL: \"%s\", Upstream-URL: \"%s\") is: %v\n", r.Identifier, r.ProjectID, r.Stage, r.APIURL, r.UpstreamURL, r.Base64EncodedSpec)
 	default:

--- a/cmd/stackit-api-manager/cmd/response_util.go
+++ b/cmd/stackit-api-manager/cmd/response_util.go
@@ -9,11 +9,12 @@ import (
 )
 
 var (
-	errEncodingCLIResponse     = fmt.Errorf("failed to encode CLI response")
-	errDecodingGatewayResponse = fmt.Errorf("failed to decode gateway response")
-	errRequestFailed           = fmt.Errorf("request failed")
-	errNilCmdResponse          = fmt.Errorf("invalid nil cmdResponse")
-	errUnknownCmdResponseType  = fmt.Errorf("unknown cmdResponse type")
+	errEncodingCLIResponseMessage     = "failed to encode CLI response"
+	errDecodingGatewayResponseMessage = "failed to decode gateway response"
+	errUnknownCmdResponseTypeMessage  = "unknown cmdResponse type"
+
+	errRequestFailed  = fmt.Errorf("request failed")
+	errNilCmdResponse = fmt.Errorf("invalid nil cmdResponse")
 )
 
 // gatewayResponse contains the HTTP status code and error message
@@ -61,8 +62,8 @@ func printSuccessCLIResponseJSON(cmd *cobra.Command, statusCode int, cmdResponse
 	}
 	jsonCLIResponse, err := json.Marshal(CLIResponse)
 	if err != nil {
-		cmd.Printf("%w: %w", errEncodingCLIResponse.Error(), err.Error())
-		return fmt.Errorf("%w: %w", errEncodingCLIResponse, err)
+		cmd.Printf("%s: %s", errEncodingCLIResponseMessage, err.Error())
+		return fmt.Errorf("%s: %w", errEncodingCLIResponseMessage, err)
 	}
 
 	cmd.Println(string(jsonCLIResponse))
@@ -83,8 +84,8 @@ func printSuccessCLIResponseHumanReadable(cmd *cobra.Command, cmdResponse cmdRes
 	case *fetchResponse:
 		cmd.Printf("Base64 encoded OpenAPI specification for API with identifier \"%s\" for project \"%s\" and stage \"%s\" (API-URL: \"%s\", Upstream-URL: \"%s\") is: %v\n", r.Identifier, r.ProjectID, r.Stage, r.APIURL, r.UpstreamURL, r.Base64EncodedSpec)
 	default:
-		cmd.Printf("%w %T", errUnknownCmdResponseType.Error(), r)
-		return fmt.Errorf("%w %T", errUnknownCmdResponseType, r)
+		cmd.Printf("%s %T", errUnknownCmdResponseTypeMessage, r)
+		return fmt.Errorf("%s %T", errUnknownCmdResponseTypeMessage, r)
 	}
 
 	return nil
@@ -94,8 +95,8 @@ func printSuccessCLIResponseHumanReadable(cmd *cobra.Command, cmdResponse cmdRes
 func printErrorCLIResponse(cmd *cobra.Command, httpResp *http.Response) error {
 	errorMessage, err := retrieveGatewayErrorMessage(httpResp)
 	if err != nil {
-		cmd.Printf("%w: %w", errDecodingGatewayResponse.Error(), err.Error())
-		return fmt.Errorf("%w: %w", errDecodingGatewayResponse, err)
+		cmd.Printf("%s: %s", errDecodingGatewayResponseMessage, err.Error())
+		return fmt.Errorf("%s: %w", errDecodingGatewayResponseMessage, err)
 	}
 
 	if printJSON {
@@ -106,8 +107,8 @@ func printErrorCLIResponse(cmd *cobra.Command, httpResp *http.Response) error {
 		}
 		jsonCLIResponse, err := json.Marshal(CLIResponse)
 		if err != nil {
-			cmd.Printf("%w: %w", errEncodingCLIResponse.Error(), err.Error())
-			return fmt.Errorf("%w: %w", errEncodingCLIResponse, err)
+			cmd.Printf("%s: %s", errEncodingCLIResponseMessage, err.Error())
+			return fmt.Errorf("%s: %w", errEncodingCLIResponseMessage, err)
 		}
 
 		cmd.Println(string(jsonCLIResponse))

--- a/cmd/stackit-api-manager/cmd/response_util.go
+++ b/cmd/stackit-api-manager/cmd/response_util.go
@@ -61,7 +61,7 @@ func printSuccessCLIResponseJSON(cmd *cobra.Command, statusCode int, cmdResponse
 	}
 	jsonCLIResponse, err := json.Marshal(CLIResponse)
 	if err != nil {
-		cmd.Printf("%w: %w", errEncodingCLIResponse, err)
+		cmd.Printf("%w: %w", errEncodingCLIResponse.Error(), err.Error())
 		return fmt.Errorf("%w: %w", errEncodingCLIResponse, err)
 	}
 
@@ -83,7 +83,7 @@ func printSuccessCLIResponseHumanReadable(cmd *cobra.Command, cmdResponse cmdRes
 	case *fetchResponse:
 		cmd.Printf("Base64 encoded OpenAPI specification for API with identifier \"%s\" for project \"%s\" and stage \"%s\" (API-URL: \"%s\", Upstream-URL: \"%s\") is: %v\n", r.Identifier, r.ProjectID, r.Stage, r.APIURL, r.UpstreamURL, r.Base64EncodedSpec)
 	default:
-		cmd.Print("%w %T", errUnknownCmdResponseType, r)
+		cmd.Printf("%w %T", errUnknownCmdResponseType.Error(), r)
 		return fmt.Errorf("%w %T", errUnknownCmdResponseType, r)
 	}
 
@@ -94,7 +94,7 @@ func printSuccessCLIResponseHumanReadable(cmd *cobra.Command, cmdResponse cmdRes
 func printErrorCLIResponse(cmd *cobra.Command, httpResp *http.Response) error {
 	errorMessage, err := retrieveGatewayErrorMessage(httpResp)
 	if err != nil {
-		cmd.Print("%w: %w", errDecodingGatewayResponse, err)
+		cmd.Printf("%w: %w", errDecodingGatewayResponse.Error(), err.Error())
 		return fmt.Errorf("%w: %w", errDecodingGatewayResponse, err)
 	}
 
@@ -106,7 +106,7 @@ func printErrorCLIResponse(cmd *cobra.Command, httpResp *http.Response) error {
 		}
 		jsonCLIResponse, err := json.Marshal(CLIResponse)
 		if err != nil {
-			cmd.Print("%w: %w", errEncodingCLIResponse, err)
+			cmd.Printf("%w: %w", errEncodingCLIResponse.Error(), err.Error())
 			return fmt.Errorf("%w: %w", errEncodingCLIResponse, err)
 		}
 

--- a/cmd/stackit-api-manager/cmd/response_util.go
+++ b/cmd/stackit-api-manager/cmd/response_util.go
@@ -11,10 +11,10 @@ import (
 var (
 	errEncodingCLIResponseMessage     = "failed to encode CLI response"
 	errDecodingGatewayResponseMessage = "failed to decode gateway response"
-	errUnknownCmdResponseTypeMessage  = "unknown cmdResponse type"
 
-	errRequestFailed  = fmt.Errorf("request failed")
-	errNilCmdResponse = fmt.Errorf("invalid nil cmdResponse")
+	errNilCmdResponse         = fmt.Errorf("invalid nil cmdResponse")
+	errUnknownCmdResponseType = fmt.Errorf("unknown cmdResponse type")
+	errRequestFailed          = fmt.Errorf("request failed")
 )
 
 // gatewayResponse contains the HTTP status code and error message
@@ -84,8 +84,8 @@ func printSuccessCLIResponseHumanReadable(cmd *cobra.Command, cmdResponse cmdRes
 	case *fetchResponse:
 		cmd.Printf("Base64 encoded OpenAPI specification for API with identifier \"%s\" for project \"%s\" and stage \"%s\" (API-URL: \"%s\", Upstream-URL: \"%s\") is: %v\n", r.Identifier, r.ProjectID, r.Stage, r.APIURL, r.UpstreamURL, r.Base64EncodedSpec)
 	default:
-		cmd.Printf("%s %T", errUnknownCmdResponseTypeMessage, r)
-		return fmt.Errorf("%s %T", errUnknownCmdResponseTypeMessage, r)
+		cmd.Printf("%s %T", errUnknownCmdResponseType.Error(), r)
+		return fmt.Errorf("%w %T", errUnknownCmdResponseType, r)
 	}
 
 	return nil

--- a/cmd/stackit-api-manager/cmd/response_util_test.go
+++ b/cmd/stackit-api-manager/cmd/response_util_test.go
@@ -414,7 +414,6 @@ func Test_printErrorCLIResponse(t *testing.T) {
 		name      string
 		args      args
 		wantPrint string
-		wantErr   bool
 	}{
 		{
 			name: "failed publish returns no error and prints JSON as expected",
@@ -424,7 +423,6 @@ func Test_printErrorCLIResponse(t *testing.T) {
 				printJSON:           true,
 				gatewayResponseBody: validGatewayResponseBody,
 			},
-			wantErr: false,
 		},
 		{
 			name: "failed publish returns no error and prints human-readable as expected",
@@ -434,7 +432,6 @@ func Test_printErrorCLIResponse(t *testing.T) {
 				printJSON:           false,
 				gatewayResponseBody: validGatewayResponseBody,
 			},
-			wantErr: false,
 		},
 		{
 			name: "failed publish with invalid gateway response (string statuscode) returns error",
@@ -443,7 +440,6 @@ func Test_printErrorCLIResponse(t *testing.T) {
 				statusCode:          testStatusCode,
 				gatewayResponseBody: invalidGatewayResponseBody,
 			},
-			wantErr: true,
 		},
 		{
 			name: "failed retire returns no error and prints JSON as expected",
@@ -453,7 +449,6 @@ func Test_printErrorCLIResponse(t *testing.T) {
 				printJSON:           true,
 				gatewayResponseBody: validGatewayResponseBody,
 			},
-			wantErr: false,
 		},
 		{
 			name: "failed retire returns no error and prints human-readable as expected",
@@ -463,7 +458,6 @@ func Test_printErrorCLIResponse(t *testing.T) {
 				printJSON:           false,
 				gatewayResponseBody: validGatewayResponseBody,
 			},
-			wantErr: false,
 		},
 		{
 			name: "failed retire with invalid gateway response (string statuscode) returns error",
@@ -472,7 +466,6 @@ func Test_printErrorCLIResponse(t *testing.T) {
 				statusCode:          testStatusCode,
 				gatewayResponseBody: invalidGatewayResponseBody,
 			},
-			wantErr: true,
 		},
 		{
 			name: "failed validate returns no error and prints JSON as expected",
@@ -482,7 +475,6 @@ func Test_printErrorCLIResponse(t *testing.T) {
 				printJSON:           true,
 				gatewayResponseBody: validGatewayResponseBody,
 			},
-			wantErr: false,
 		},
 		{
 			name: "failed validate returns no error and prints human-readable as expected",
@@ -492,7 +484,6 @@ func Test_printErrorCLIResponse(t *testing.T) {
 				printJSON:           false,
 				gatewayResponseBody: validGatewayResponseBody,
 			},
-			wantErr: false,
 		},
 		{
 			name: "failed validate with invalid gateway response (string statuscode) returns error",
@@ -501,7 +492,6 @@ func Test_printErrorCLIResponse(t *testing.T) {
 				statusCode:          testStatusCode,
 				gatewayResponseBody: invalidGatewayResponseBody,
 			},
-			wantErr: true,
 		},
 		{
 			name: "failed list returns no error and prints JSON as expected",
@@ -511,7 +501,6 @@ func Test_printErrorCLIResponse(t *testing.T) {
 				printJSON:           true,
 				gatewayResponseBody: validGatewayResponseBody,
 			},
-			wantErr: false,
 		},
 		{
 			name: "failed list returns no error and prints human-readable as expected",
@@ -521,7 +510,6 @@ func Test_printErrorCLIResponse(t *testing.T) {
 				printJSON:           false,
 				gatewayResponseBody: validGatewayResponseBody,
 			},
-			wantErr: false,
 		},
 		{
 			name: "failed list with invalid gateway response (string statuscode) returns error",
@@ -530,7 +518,6 @@ func Test_printErrorCLIResponse(t *testing.T) {
 				statusCode:          testStatusCode,
 				gatewayResponseBody: invalidGatewayResponseBody,
 			},
-			wantErr: true,
 		},
 		{
 			name: "failed fetch returns no error and prints JSON as expected",
@@ -540,7 +527,6 @@ func Test_printErrorCLIResponse(t *testing.T) {
 				printJSON:           true,
 				gatewayResponseBody: validGatewayResponseBody,
 			},
-			wantErr: false,
 		},
 		{
 			name: "failed fetch returns no error and prints human-readable as expected",
@@ -550,7 +536,6 @@ func Test_printErrorCLIResponse(t *testing.T) {
 				printJSON:           false,
 				gatewayResponseBody: validGatewayResponseBody,
 			},
-			wantErr: false,
 		},
 		{
 			name: "failed fetch with invalid gateway response (string statuscode) returns error",
@@ -559,7 +544,6 @@ func Test_printErrorCLIResponse(t *testing.T) {
 				statusCode:          testStatusCode,
 				gatewayResponseBody: invalidGatewayResponseBody,
 			},
-			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
@@ -574,9 +558,10 @@ func Test_printErrorCLIResponse(t *testing.T) {
 
 			printJSON = tt.args.printJSON
 
+			wantErr := true
 			gotErr := printErrorCLIResponse(tt.args.cmd, httpResp)
-			if (gotErr != nil) != tt.wantErr {
-				t.Errorf("printErrorCLIResponse() got error = %v, want %v", gotErr, tt.wantErr)
+			if (gotErr != nil) != wantErr {
+				t.Errorf("printErrorCLIResponse() got error = %v, want %v", gotErr, wantErr)
 			}
 
 			wantPrint := fmt.Sprintf("Failed to %s! An error occurred with statuscode %d: %s", tt.args.cmd.Use, testStatusCode, testErrorMessage)


### PR DESCRIPTION
- return nonzero status code if request was not successful (for users who want to include the CLI into their CI/CD pipeline based on the status code)
- take over responsibility for error printing using cobra tool (errors would be printed twice otherwise and json response on unsuccessful request would include cobra error message in plain format)