### PR TITLE
feat: print linter warnings on validate

### DIFF
--- a/cmd/stackit-api-manager/cmd/project_validate.go
+++ b/cmd/stackit-api-manager/cmd/project_validate.go
@@ -13,9 +13,11 @@ import (
 const messageValidateSuccess = "OpenAPI specification validated successfully"
 
 type validateResponse struct {
-	Identifier string `json:"identifier"`
-	ProjectID  string `json:"projectId"`
-	Stage      string `json:"stage"`
+	Identifier          string   `json:"identifier"`
+	ProjectID           string   `json:"projectId"`
+	Stage               string   `json:"stage"`
+	LinterWarningsCount string   `json:"linter_warnings_count,omitempty"`
+	LinterWarnings      []string `json:"linter_warnings,omitempty"`
 }
 
 func (r validateResponse) successMessage() string {
@@ -57,7 +59,7 @@ func validateCmdRunE(cmd *cobra.Command, args []string) error {
 	// add auth token
 	ctx := context.WithValue(context.Background(), apiManager.ContextAccessToken, authToken)
 
-	_, httpResp, err := c.APIManagerServiceApi.APIManagerServicePublishValidate(
+	grpcResp, httpResp, err := c.APIManagerServiceApi.APIManagerServicePublishValidate(
 		ctx,
 		projectID,
 		identifier,
@@ -73,9 +75,11 @@ func validateCmdRunE(cmd *cobra.Command, args []string) error {
 	}
 
 	validateResponse := &validateResponse{
-		Identifier: identifier,
-		ProjectID:  projectID,
-		Stage:      stage,
+		Identifier:          identifier,
+		ProjectID:           projectID,
+		Stage:               stage,
+		LinterWarnings:      grpcResp.GetLinterWarnings(),
+		LinterWarningsCount: grpcResp.GetLinterWarningsCount(),
 	}
 
 	return printSuccessCLIResponse(cmd, httpResp.StatusCode, validateResponse)

--- a/cmd/stackit-api-manager/cmd/response_util.go
+++ b/cmd/stackit-api-manager/cmd/response_util.go
@@ -79,7 +79,7 @@ func printSuccessCLIResponseHumanReadable(cmd *cobra.Command, cmdResponse cmdRes
 	case *retireResponse:
 		cmd.Printf("API with identifier \"%s\" retired successfully for project \"%s\"\n", r.Identifier, r.ProjectID)
 	case *validateResponse:
-		if r.LinterWarningsCount != "" {
+		if r.LinterWarningsCount != "0" && r.LinterWarningsCount != "" {
 			cmd.Printf("OpenAPI specification for API with identifier \"%s\", project \"%s\" and stage \"%s\" validated successfully\nOAS linting resulted in %s warnings:\n  %+s\n", r.Identifier, r.ProjectID, r.Stage, r.LinterWarningsCount, strings.Join(r.LinterWarnings, "\n  "))
 			break
 		}

--- a/cmd/stackit-api-manager/cmd/response_util.go
+++ b/cmd/stackit-api-manager/cmd/response_util.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -78,6 +79,10 @@ func printSuccessCLIResponseHumanReadable(cmd *cobra.Command, cmdResponse cmdRes
 	case *retireResponse:
 		cmd.Printf("API with identifier \"%s\" retired successfully for project \"%s\"\n", r.Identifier, r.ProjectID)
 	case *validateResponse:
+		if r.LinterWarningsCount != "" {
+			cmd.Printf("OpenAPI specification for API with identifier \"%s\", project \"%s\" and stage \"%s\" validated successfully\nOAS linting resulted in %s warnings:\n  %+s\n", r.Identifier, r.ProjectID, r.Stage, r.LinterWarningsCount, strings.Join(r.LinterWarnings, "\n  "))
+			break
+		}
 		cmd.Printf("OpenAPI specification for API with identifier \"%s\", project \"%s\" and stage \"%s\" validated successfully\n", r.Identifier, r.ProjectID, r.Stage)
 	case *listResponse:
 		cmd.Printf("Project \"%s\" has the following identifiers: %+v\n", r.ProjectID, r.Identifiers)

--- a/cmd/stackit-api-manager/cmd/response_util_test.go
+++ b/cmd/stackit-api-manager/cmd/response_util_test.go
@@ -278,7 +278,7 @@ func Test_printSuccessCLIResponseJSON(t *testing.T) {
 			gotPrint := strings.TrimRight(string(gotPrintBytes), "\n")
 
 			if gotErr == nil && gotPrint != tt.wantPrint {
-				t.Errorf("printSuccessCLIResponseJSON() expected message to be\nABC%vABC\nbut got\nABC%vABC", tt.wantPrint, gotPrint)
+				t.Errorf("printSuccessCLIResponseJSON() expected message to be\n%v\nbut got\n%v", tt.wantPrint, gotPrint)
 			}
 		})
 	}


### PR DESCRIPTION
makes use of the linterWarningsCount and linterWarnings fields from the PublishValidate grpc response by printing the values on validate

Example with warnings:
![Screenshot from 2023-03-28 20-02-19](https://user-images.githubusercontent.com/24920790/228328192-54e490bd-c64f-4ae5-b8c5-b2172d3e66cf.png)

For an OAS without warnings, the output is the same as before.
